### PR TITLE
Fix link to the grading repos page

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,5 +37,5 @@ class: grid
 </section>
 
 <section class="section">
-Mein Leitfaden für die <a href="notes-on-code/">Bewertung von Code Repositories</a>.
+Mein Leitfaden für die <a href="notes-on-code">Bewertung von Code Repositories</a>.
 </section>


### PR DESCRIPTION
Fix link on `index.html`, which right now won't resolve and throw a 404.